### PR TITLE
Remove "CLA signed" status from views

### DIFF
--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -17,11 +17,6 @@
   <tr id="member-<%= member.id %>" class="<%= cycle 'odd', 'even' %> member">
     <td class="<%= member.principal.class.name.downcase %>">
       <%= link_to_user member.principal %>
-      <% if member.user.signed_cla? %>
-      (CLA signed)
-      <% else %>
-      (<b>No</b> <a href="http://typo3.org/about/licenses/">CLA</a> signed)
-    <% end %>
   </td>
   <td class="roles">
     <span id="member-<%= member.id %>-roles"><%=h member.roles.sort.collect(&:to_s).join(', ') %></span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,11 +8,6 @@
 <p>
 <%= output_user_image @user, 2 %>
 </p>
-<% if @user.signed_cla? %>
-  <p>has signed the <a href="http://typo3.org/about/licenses/">Contributor License Agreement</a></p>
-<% else %>
-  <p><b>has not signed the <a href="http://typo3.org/about/licenses/">Contributor License Agreement</a></b></p>
-<% end %>
 <p>
 <%= format_mail @user %>
 


### PR DESCRIPTION
This removes the hint, whether a user has signed the CLA from the user's
profile page as well as from the project setting's member list.

This does not yet remove the field from the model, as this is part of the
flow_sso plugin.
